### PR TITLE
Improve image resolution and scrollview content on iOS

### DIFF
--- a/android/src/main/java/com/rumax/reactnative/saveview/SaveView.java
+++ b/android/src/main/java/com/rumax/reactnative/saveview/SaveView.java
@@ -76,8 +76,6 @@ public class SaveView {
 
     if (bgDrawable != null) {
       bgDrawable.draw(canvas);
-    } else {
-      canvas.drawColor(Color.WHITE);
     }
 
     view.draw(canvas);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-save-view",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "React native save View implementation",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
- Draw complete scrollview content when making image
- Use `UIGraphicsBeginImageContextWithOptions(size, NO, 0);` to improve image resolution
- Remove setting default backgroundColor when view has none

### Description of changes

- Draw complete scrollview content when making image
- Use `UIGraphicsBeginImageContextWithOptions(size, NO, 0);` to improve image resolution

### I did Exploratory testing
  - [x] ~~android~~
  - [x] ios

### Can it be published to NPM?
  - [x] Breaking change
  - [x] ~~Documentation is updated~~
